### PR TITLE
Fix path for listing context variables

### DIFF
--- a/context.go
+++ b/context.go
@@ -163,7 +163,7 @@ func (s *contexts) ListVariables(ctx context.Context, contextID string) (*Contex
 		return nil, ErrRequiredContextID
 	}
 
-	u := fmt.Sprintf("context/%s", contextID)
+	u := fmt.Sprintf("context/%s/environment-variable", contextID)
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/context_test.go
+++ b/context_test.go
@@ -130,7 +130,7 @@ func Test_contexts_ListVariables(t *testing.T) {
 
 	contextID := "ctx1"
 
-	mux.HandleFunc(fmt.Sprintf("/context/%s", contextID), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("/context/%s/environment-variable", contextID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testHeader(t, r, "Accept", "application/json")
 		testHeader(t, r, "Circle-Token", client.token)


### PR DESCRIPTION
The URL for listing environment variables in a context is incorrect. The proposed change should fix the problem.