### PR TITLE
Add pagination to `project` endpoint

### DIFF
--- a/project.go
+++ b/project.go
@@ -14,7 +14,7 @@ type Projects interface {
 	GetCheckoutKey(ctx context.Context, projectSlug, fingerprint string) (*ProjectCheckoutKey, error)
 	DeleteCheckoutKey(ctx context.Context, projectSlug, fingerprint string) error
 	CreateVariable(ctx context.Context, projectSlug string, options ProjectCreateVariableOptions) (*ProjectVariable, error)
-	ListVariables(ctx context.Context, projectSlug string) (*ProjectVariableList, error)
+	ListVariables(ctx context.Context, projectSlug string, options ProjectListVariablesOptions) (*ProjectVariableList, error)
 	DeleteVariable(ctx context.Context, projectSlug, name string) error
 	GetVariable(ctx context.Context, projectSlug, name string) (*ProjectVariable, error)
 	TriggerPipeline(ctx context.Context, projectSlug string, options ProjectTriggerPipelineOptions) (*Pipeline, error)
@@ -234,18 +234,22 @@ func (s *projects) CreateVariable(ctx context.Context, projectSlug string, optio
 	return pv, nil
 }
 
+type ProjectListVariablesOptions struct {
+	PageToken *string `url:"page-token,omitempty"`
+}
+
 type ProjectVariableList struct {
 	Items         []*ProjectVariable `json:"items"`
 	NextPageToken string             `json:"next_page_token"`
 }
 
-func (s *projects) ListVariables(ctx context.Context, projectSlug string) (*ProjectVariableList, error) {
+func (s *projects) ListVariables(ctx context.Context, projectSlug string, options ProjectListVariablesOptions) (*ProjectVariableList, error) {
 	if !validString(&projectSlug) {
 		return nil, ErrRequiredProjectSlug
 	}
 
 	u := fmt.Sprintf("project/%s/envvar", projectSlug)
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/project.go
+++ b/project.go
@@ -10,7 +10,7 @@ import (
 type Projects interface {
 	Get(ctx context.Context, projectSlug string) (*Project, error)
 	CreateCheckoutKey(ctx context.Context, projectSlug string, options ProjectCreateCheckoutKeyOptions) (*ProjectCheckoutKey, error)
-	ListCheckoutKeys(ctx context.Context, projectSlug string) (*ProjectCheckoutKeyList, error)
+	ListCheckoutKeys(ctx context.Context, projectSlug string, options ProjectListCheckoutKeysOptions) (*ProjectCheckoutKeyList, error)
 	GetCheckoutKey(ctx context.Context, projectSlug, fingerprint string) (*ProjectCheckoutKey, error)
 	DeleteCheckoutKey(ctx context.Context, projectSlug, fingerprint string) error
 	CreateVariable(ctx context.Context, projectSlug string, options ProjectCreateVariableOptions) (*ProjectVariable, error)
@@ -117,18 +117,22 @@ func (s *projects) CreateCheckoutKey(ctx context.Context, projectSlug string, op
 	return pck, nil
 }
 
+type ProjectListCheckoutKeysOptions struct {
+	PageToken *string `url:"page-token,omitempty"`
+}
+
 type ProjectCheckoutKeyList struct {
 	Items         []*ProjectCheckoutKey `json:"items"`
 	NextPageToken string                `json:"next_page_token"`
 }
 
-func (s *projects) ListCheckoutKeys(ctx context.Context, projectSlug string) (*ProjectCheckoutKeyList, error) {
+func (s *projects) ListCheckoutKeys(ctx context.Context, projectSlug string, options ProjectListCheckoutKeysOptions) (*ProjectCheckoutKeyList, error) {
 	if !validString(&projectSlug) {
 		return nil, ErrRequiredProjectSlug
 	}
 
 	u := fmt.Sprintf("project/%s/checkout-key", projectSlug)
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/project.go
+++ b/project.go
@@ -23,7 +23,7 @@ type Projects interface {
 	GetPipeline(ctx context.Context, projectSlug string, pipelineNumber string) (*Pipeline, error)
 }
 
-// projects implementes Projects interface
+// projects implements Projects interface
 type projects struct {
 	client *Client
 }
@@ -70,15 +70,15 @@ func (s *projects) Get(ctx context.Context, projectSlug string) (*Project, error
 }
 
 type ProjectCheckoutKey struct {
-        // seems like public documentation says public-key should be the key but
-        // actually returned one is public_key
+	// seems like public documentation says public-key should be the key but
+	// actually returned one is public_key
 	PublicKey   string              `json:"public_key"`
 	Type        CheckoutKeyTypeType `json:"type"`
 	Fingerprint string              `json:"fingerprint"`
 	Preferred   bool                `json:"preferred"`
-        // seems like public documentation says created-at should be the key but
-        // actually returned one is created_at
-	CreatedAt   time.Time           `json:"created_at"`
+	// seems like public documentation says created-at should be the key but
+	// actually returned one is created_at
+	CreatedAt time.Time `json:"created_at"`
 }
 
 type ProjectCreateCheckoutKeyOptions struct {

--- a/project_test.go
+++ b/project_test.go
@@ -203,7 +203,7 @@ func Test_projects_ListVariables(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	pvl, err := client.Projects.ListVariables(ctx, projectSlug)
+	pvl, err := client.Projects.ListVariables(ctx, projectSlug, ProjectListVariablesOptions{})
 	if err != nil {
 		t.Errorf("Projects.ListVariables got error: %v", err)
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -85,7 +85,7 @@ func Test_projects_ListCheckoutKeys(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	pckl, err := client.Projects.ListCheckoutKeys(ctx, projectSlug)
+	pckl, err := client.Projects.ListCheckoutKeys(ctx, projectSlug, ProjectListCheckoutKeysOptions{})
 	if err != nil {
 		t.Errorf("Projects.ListCheckoutKeys got error: %v", err)
 	}


### PR DESCRIPTION
This PR is not "clean" as it does not 100% represent what CircleCI API can do, so it's up to author to consider merging or closing. Below is my case in favor of merge.

---

This PR adds pagination for [`Projects.ListCheckoutKeys`](https://github.com/grezar/go-circleci/commit/2513cf0dc4c1066cd19a00ea88f67e1528221f32) and [`Projects.ListVariables`](https://github.com/grezar/go-circleci/commit/d4d42d0d9e090a7b6965905afa6d6ca89a8216dd). `page-token` query parameter is actually not respected on the CircleCI side.

I'd like to add this, because in both cases response contains `next_page_token`. This then allows writing code:

```go
for {
	chunk, err := client.Projects.ListVariables(ctx, "slug", opts)
	if err != nil {
		return nil, err
	}

	variables = append(variables, chunk.Items...)
	if chunk.NextPageToken == "" {
		break
	}

	opts.PageToken = &chunk.NextPageToken
}
```

References:
- https://circleci.com/docs/api/v2/index.html#operation/listCheckoutKeys
- https://circleci.com/docs/api/v2/index.html#operation/listEnvVars
