### PR TITLE
Align type with other `*Options`

### DIFF
--- a/context.go
+++ b/context.go
@@ -153,7 +153,7 @@ type ContextVariableList struct {
 }
 
 type ContextListVariablesOptions struct {
-	PageToken string `url:"page-token,omitempty"`
+	PageToken *string `url:"page-token,omitempty"`
 }
 
 type ContextVariable struct {


### PR DESCRIPTION
This PR fixes misalignment introduced in #30.