### PR TITLE
fix: fixes typo in method name

### DIFF
--- a/insight.go
+++ b/insight.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Insights interface {
-	ListSummaryMetricsForWorkflos(ctx context.Context, projectSlug string, options InsightsListSummaryMetricsOptions) (*SummaryMetricsList, error)
+	ListSummaryMetricsForWorkflows(ctx context.Context, projectSlug string, options InsightsListSummaryMetricsOptions) (*SummaryMetricsList, error)
 	ListSummaryMetricsForWorkflowJobs(ctx context.Context, projectSlug, workflowName string, options InsightsListSummaryMetricsOptions) (*SummaryMetricsList, error)
 	GetTestMetricsForWorkflows(ctx context.Context, projectSlug, workflowName string, options InsightsGetTestMetricsOptions) (*TestMetrics, error)
 	ListWorkflowRuns(ctx context.Context, projectSlug, workflowName string, options InsightsListWorkflowRunsOptions) (*WorkflowRunList, error)
@@ -75,7 +75,7 @@ func (o InsightsListSummaryMetricsOptions) valid() error {
 	return nil
 }
 
-func (s *insights) ListSummaryMetricsForWorkflos(ctx context.Context, projectSlug string, options InsightsListSummaryMetricsOptions) (*SummaryMetricsList, error) {
+func (s *insights) ListSummaryMetricsForWorkflows(ctx context.Context, projectSlug string, options InsightsListSummaryMetricsOptions) (*SummaryMetricsList, error) {
 	if err := options.valid(); err != nil {
 		return nil, err
 	}

--- a/insight_test.go
+++ b/insight_test.go
@@ -27,13 +27,13 @@ func Test_insights_ListSummaryMetricsForWorkflows(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	sml, err := client.Insights.ListSummaryMetricsForWorkflos(ctx, projectSlug, InsightsListSummaryMetricsOptions{
+	sml, err := client.Insights.ListSummaryMetricsForWorkflows(ctx, projectSlug, InsightsListSummaryMetricsOptions{
 		PageToken:       String("1"),
 		AllBranches:     Bool(true),
 		ReportingWindow: ReportingWindow(Last90Days),
 	})
 	if err != nil {
-		t.Errorf("Insights.ListSummaryMetricsForWorkflos got error: %v", err)
+		t.Errorf("Insights.ListSummaryMetricsForWorkflows got error: %v", err)
 	}
 
 	want := &SummaryMetricsList{
@@ -46,7 +46,7 @@ func Test_insights_ListSummaryMetricsForWorkflows(t *testing.T) {
 	}
 
 	if !cmp.Equal(sml, want) {
-		t.Errorf("Insights.ListSummaryMetricsForWorkflos got %+v, want %+v", sml, want)
+		t.Errorf("Insights.ListSummaryMetricsForWorkflows got %+v, want %+v", sml, want)
 	}
 }
 

--- a/mocks/insight.go
+++ b/mocks/insight.go
@@ -50,19 +50,19 @@ func (mr *MockInsightsMockRecorder) GetTestMetricsForWorkflows(ctx, projectSlug,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTestMetricsForWorkflows", reflect.TypeOf((*MockInsights)(nil).GetTestMetricsForWorkflows), ctx, projectSlug, workflowName, options)
 }
 
-// ListSummaryMetricsForWorkflos mocks base method.
-func (m *MockInsights) ListSummaryMetricsForWorkflos(ctx context.Context, projectSlug string, options circleci.InsightsListSummaryMetricsOptions) (*circleci.SummaryMetricsList, error) {
+// ListSummaryMetricsForWorkflows mocks base method.
+func (m *MockInsights) ListSummaryMetricsForWorkflows(ctx context.Context, projectSlug string, options circleci.InsightsListSummaryMetricsOptions) (*circleci.SummaryMetricsList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSummaryMetricsForWorkflos", ctx, projectSlug, options)
+	ret := m.ctrl.Call(m, "ListSummaryMetricsForWorkflows", ctx, projectSlug, options)
 	ret0, _ := ret[0].(*circleci.SummaryMetricsList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListSummaryMetricsForWorkflos indicates an expected call of ListSummaryMetricsForWorkflos.
-func (mr *MockInsightsMockRecorder) ListSummaryMetricsForWorkflos(ctx, projectSlug, options interface{}) *gomock.Call {
+// ListSummaryMetricsForWorkflows indicates an expected call of ListSummaryMetricsForWorkflows.
+func (mr *MockInsightsMockRecorder) ListSummaryMetricsForWorkflows(ctx, projectSlug, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSummaryMetricsForWorkflos", reflect.TypeOf((*MockInsights)(nil).ListSummaryMetricsForWorkflos), ctx, projectSlug, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSummaryMetricsForWorkflows", reflect.TypeOf((*MockInsights)(nil).ListSummaryMetricsForWorkflows), ctx, projectSlug, options)
 }
 
 // ListSummaryMetricsForWorkflowJobs mocks base method.


### PR DESCRIPTION
there is currently a [typo](https://github.com/grezar/go-circleci/blob/main/insight.go#L11) in one of the methods for insights