### PR TITLE
Add detail for HTTP error

### DIFF
--- a/circleci.go
+++ b/circleci.go
@@ -227,5 +227,5 @@ func checkResponseCode(r *http.Response) error {
 		return errors.New(r.Status)
 	}
 
-	return errors.New(errResponse.Message)
+	return fmt.Errorf("response_code: %d, error_message: %s", r.StatusCode, errResponse.Message)
 }


### PR DESCRIPTION
When I receive an error from CircleCI API, `go-circleci` returns an error message only. So I want to know more details about the HTTP error.